### PR TITLE
Include OTF font files in assets

### DIFF
--- a/discourse-fonts.gemspec
+++ b/discourse-fonts.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.description = "Bundle of fonts which can be used to customize the look of Discourse"
   s.authors     = ["Bianca Nenciu"]
   s.email       = "bianca.nenciu@discourse.org"
-  s.files       = Dir["lib/*.rb", "vendor/assets/fonts/*.ttf", "vendor/assets/fonts/*.woff", "vendor/assets/fonts/*.woff2"]
+  s.files       = Dir["lib/*.rb", "vendor/assets/fonts/*.ttf", "vendor/assets/fonts/*.woff", "vendor/assets/fonts/*.woff2", "vendor/assets/fonts/*.otf"]
   s.homepage    = "https://github.com/discourse/discourse-fonts"
   s.license     = "MIT"
 end

--- a/lib/discourse_fonts.rb
+++ b/lib/discourse_fonts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DiscourseFonts
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 
   def self.path_for_fonts
     File.expand_path("../../vendor/assets/fonts", __FILE__)


### PR DESCRIPTION
Fixes an issue with missing font files for NotoSansJP. 