### PR TITLE
FIX: Add 700 weight variant for Inter

### DIFF
--- a/lib/discourse_fonts.rb
+++ b/lib/discourse_fonts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DiscourseFonts
-  VERSION = "0.0.12"
+  VERSION = "0.0.13"
 
   def self.path_for_fonts
     File.expand_path("../../vendor/assets/fonts", __FILE__)
@@ -55,7 +55,11 @@ module DiscourseFonts
         {
           name: "Inter",
           stack: "Inter, Arial, sans-serif",
-          variants: [{ filename: "Inter.ttf", format: "truetype", weight: 400 }]
+          # Inter is variable font, so the same .ttf file is used for all weights.
+          variants: [
+            { filename: "Inter.ttf", format: "truetype", weight: 400 },
+            { filename: "Inter.ttf", format: "truetype", weight: 700 }
+          ]
         },
         {
           name: "NotoSansJP",


### PR DESCRIPTION
Followup  5be751e94674fe54f02d02d338cf89e820e584ca

In the previous commit we added Inter as a font
selection, but at the time since it was variable weight we didn't add a 700 weight variant out of concern for other issues that may arise from this.

However leaving it out has had actual real-world issues, whether the bold variation does not render correctly in some browsers (e.g. Chrome on macOS, Firefox). Adding the 700 weight here fixes that issue.

**macOS Chrome, before**

<img width="213" alt="image" src="https://github.com/user-attachments/assets/a35f14f7-c4c7-461a-8755-0290f24b0353" />

**macOS Chrome, after**

<img width="222" alt="image" src="https://github.com/user-attachments/assets/447bd335-a681-4895-a45e-e7c9a7648495" />

**Linux Firefox, before**

![image](https://github.com/user-attachments/assets/ed02820e-3b0b-4f84-b118-10b464e2417b)

**Linux Firefox, after**

![image](https://github.com/user-attachments/assets/1001c295-d577-47a0-a0a4-39dbf287b846)


