### PR TITLE
FEATURE: Add special font properties to Inter

### DIFF
--- a/lib/discourse_fonts.rb
+++ b/lib/discourse_fonts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DiscourseFonts
-  VERSION = "0.0.14"
+  VERSION = "0.0.15"
 
   def self.path_for_fonts
     File.expand_path("../../vendor/assets/fonts", __FILE__)
@@ -55,9 +55,15 @@ module DiscourseFonts
         {
           name: "Inter",
           stack: "Inter, Arial, sans-serif",
+          font_feature_settings: "'calt' 0, 'ccmp' 0, 'ss02' 1",
+          font_variation_settings: "'opsz' 28",
           # Inter is variable font, so the same file is used for all weights.
           variants: [
-            { filename: "InterVariable.woff2", format: "woff2", weight: "100 900" },
+            {
+              filename: "InterVariable.woff2",
+              format: "woff2",
+              weight: "100 900"
+            }
           ]
         },
         {


### PR DESCRIPTION
This commit adds the following for Inter:

```ruby
font_feature_settings: "'calt' 0, 'ccmp' 0, 'ss02' 1",
font_variation_settings: "'opsz' 28",
```

In core, these will be translated to the appropriate CSS
props:

```css
font-variation-settings: "opsz" 28;
font-feature-settings: "calt" 0, "ccmp" 0, "ss02" 1;
```

Inter has these and other special features defined at
https://rsms.me/inter/#features . We don't want calt and ccmp
defined because they conflict with our built-in markdown
typographer.
