### PR TITLE
FIX: Use ss04 instead of ss02 for Inter

### DIFF
--- a/lib/discourse_fonts.rb
+++ b/lib/discourse_fonts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DiscourseFonts
-  VERSION = "0.0.15"
+  VERSION = "0.0.16"
 
   def self.path_for_fonts
     File.expand_path("../../vendor/assets/fonts", __FILE__)
@@ -55,7 +55,7 @@ module DiscourseFonts
         {
           name: "Inter",
           stack: "Inter, Arial, sans-serif",
-          font_feature_settings: "'calt' 0, 'ccmp' 0, 'ss02' 1",
+          font_feature_settings: "'calt' 0, 'ccmp' 0, 'ss04' 1",
           font_variation_settings: "'opsz' 28",
           # Inter is variable font, so the same file is used for all weights.
           variants: [


### PR DESCRIPTION
People don't like the slash inside 0, we can
use ss04 which uses all the other character disambiguations
but _not_ 0.
