### PR TITLE
remove optical sizing for now as well and keep ccmp on default.

### DIFF
--- a/lib/discourse_fonts.rb
+++ b/lib/discourse_fonts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DiscourseFonts
-  VERSION = "0.0.16"
+  VERSION = "0.0.17"
 
   def self.path_for_fonts
     File.expand_path("../../vendor/assets/fonts", __FILE__)
@@ -55,8 +55,9 @@ module DiscourseFonts
         {
           name: "Inter",
           stack: "Inter, Arial, sans-serif",
-          font_feature_settings: "'calt' 0, 'ccmp' 0",
-          font_variation_settings: "'opsz' 28",
+          font_feature_settings: "'calt' 0",
+          # calt is enabled by default, but we need to disable it so it does no conflict with markdown typographer which
+          # performs similar oprations.
           # Inter is variable font, so the same file is used for all weights.
           variants: [
             {


### PR DESCRIPTION
ccmp composes chars so A⃝ into an A with a circle around it.
Inter recommends this is default enabled and Microsoft do as well.

Odds of hitting edge cases in the wild are rare given: https://github.com/rsms/inter/blob/master/src/features/ccmp.fea

Additional, optical sizing is a stylistic choice, it can hurt readability on small text but make it better on big text. Let's leave this out for now.

Inter website recommends liga 1, but this advise seems out of date as no new browser is impacted by whatever bug it was.

