### PR TITLE
DEV: update system font stack to `system-ui`

### DIFF
--- a/lib/discourse_fonts.rb
+++ b/lib/discourse_fonts.rb
@@ -13,8 +13,7 @@ module DiscourseFonts
         { name: "Arial", stack: "Arial, sans-serif" },
         {
           name: "System",
-          stack:
-            "-apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, Oxygen-Sans, Ubuntu, Cantarell, \"Helvetica Neue\", sans-serif"
+          stack: "system-ui, Arial, sans-serif"
         },
         {
           name: "Open Sans",


### PR DESCRIPTION
Corresponds with this core change: https://github.com/discourse/discourse/commit/0989c4b0a41ed43d5bde96b1e04ffb76c895d458